### PR TITLE
Support encoding/decoding of case classes with > 22 fields.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.16, 3.6.4]
+        scala: [2.13.16, 3.3.5]
         java: [temurin@11, temurin@17]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,5 @@
 version = "3.9.4"
+runner.dialect = scala213
 maxColumn = 120
 align.preset = most
 continuationIndent.defnSite = 2

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
 version = "3.9.5"
-runner.dialect = scala213
+runner.dialect = scala3
 maxColumn = 120
 align.preset = most
 continuationIndent.defnSite = 2

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import BuildHelper._
+import org.typelevel.scalacoptions.ScalacOptions
 
 inThisBuild(
   List(
@@ -21,7 +22,7 @@ inThisBuild(
       )
     ),
     crossScalaVersions                  := Seq(Scala213, Scala3),
-    ThisBuild / scalaVersion            := Scala3,
+    scalaVersion                        := Scala213,
     githubWorkflowJavaVersions          := Seq(JavaSpec.temurin("11"), JavaSpec.temurin("17")),
     githubWorkflowPublishTargetBranches := Seq(),
     githubWorkflowBuildPreamble         := Seq(
@@ -50,6 +51,13 @@ lazy val core =
     .in(file("modules/core"))
     .settings(
       stdSettings("core"),
+      tpolecatSettings,
       libraryDependencies ++= Dep.core,
       testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
     )
+
+val tpolecatSettings =
+  Seq(
+    tpolecatScalacOptions += ScalacOptions.source3,
+    tpolecatExcludeOptions += ScalacOptions.lintInferAny
+  )

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ inThisBuild(
       )
     ),
     crossScalaVersions                  := Seq(Scala213, Scala3),
-    scalaVersion                        := Scala213,
+    scalaVersion                        := Scala3,
     githubWorkflowJavaVersions          := Seq(JavaSpec.temurin("11"), JavaSpec.temurin("17")),
     githubWorkflowPublishTargetBranches := Seq(),
     githubWorkflowBuildPreamble         := Seq(

--- a/docs/scala-cli/Filtering.scala
+++ b/docs/scala-cli/Filtering.scala
@@ -1,5 +1,5 @@
 //> using scala "3.5.0"
-//> using dep me.mnedokushev::zio-apache-parquet-core:0.1.9
+//> using dep me.mnedokushev::zio-apache-parquet-core:0.1.12
 
 import zio.*
 import zio.schema.*

--- a/docs/scala-cli/ParquetIO.scala
+++ b/docs/scala-cli/ParquetIO.scala
@@ -1,5 +1,5 @@
 //> using scala "3.5.0"
-//> using dep me.mnedokushev::zio-apache-parquet-core:0.1.9
+//> using dep me.mnedokushev::zio-apache-parquet-core:0.1.12
 
 import zio.schema.*
 import me.mnedokushev.zio.apache.parquet.core.codec.*

--- a/docs/scala-cli/Schema.scala
+++ b/docs/scala-cli/Schema.scala
@@ -1,5 +1,5 @@
-//> using scala "3.5.0"
-//> using dep me.mnedokushev::zio-apache-parquet-core:0.1.9
+//> using scala "3.6.4"
+//> using dep me.mnedokushev::zio-apache-parquet-core:0.1.12
 
 import zio.schema.*
 import me.mnedokushev.zio.apache.parquet.core.codec.*

--- a/docs/scala-cli/SchemaArity23.scala
+++ b/docs/scala-cli/SchemaArity23.scala
@@ -1,0 +1,46 @@
+//> using scala "2.13.16"
+//> using dep me.mnedokushev::zio-apache-parquet-core:0.2.0
+
+import zio.schema._
+import me.mnedokushev.zio.apache.parquet.core.codec._
+
+object SchemaArity23 extends App {
+
+  final case class Arity23(
+    a: Int,
+    b: Option[String],
+    c: Int,
+    d: Int,
+    e: Int,
+    f: Int,
+    g: Int,
+    h: Int,
+    i: Int,
+    j: Int,
+    k: Int,
+    l: Int,
+    m: Int,
+    n: Int,
+    o: Int,
+    p: Int,
+    q: Int,
+    r: Int,
+    s: Int,
+    t: Int,
+    u: Int,
+    v: Int,
+    w: Int
+  )
+
+  object Arity23 {
+    implicit val schema: Schema[Arity23]               =
+      DeriveSchema.gen[Arity23]
+    implicit val schemaEncoder: SchemaEncoder[Arity23] =
+      Derive.derive[SchemaEncoder, Arity23](SchemaEncoderDeriver.default)
+  }
+
+  val arity23Schema = Arity23.schemaEncoder.encode(Arity23.schema, "arity23", optional = false)
+
+  println(arity23Schema)
+
+}

--- a/docs/scala-cli/SchemaSummoned.scala
+++ b/docs/scala-cli/SchemaSummoned.scala
@@ -1,5 +1,5 @@
 //> using scala "3.5.0"
-//> using dep me.mnedokushev::zio-apache-parquet-core:0.1.9
+//> using dep me.mnedokushev::zio-apache-parquet-core:0.1.12
 
 import me.mnedokushev.zio.apache.parquet.core.Schemas
 import zio.schema.*

--- a/docs/scala-cli/Value.scala
+++ b/docs/scala-cli/Value.scala
@@ -1,5 +1,5 @@
 //> using scala "3.5.0"
-//> using dep me.mnedokushev::zio-apache-parquet-core:0.1.9
+//> using dep me.mnedokushev::zio-apache-parquet-core:0.1.12
 
 import zio.schema.*
 import me.mnedokushev.zio.apache.parquet.core.codec.*

--- a/docs/scala-cli/ValueSummoned.scala
+++ b/docs/scala-cli/ValueSummoned.scala
@@ -1,5 +1,5 @@
 //> using scala "3.5.0"
-//> using dep me.mnedokushev::zio-apache-parquet-core:0.1.9
+//> using dep me.mnedokushev::zio-apache-parquet-core:0.1.12
 
 import me.mnedokushev.zio.apache.parquet.core.Value
 import zio.schema.*

--- a/modules/core/src/main/scala/me/mnedokushev/zio/apache/parquet/core/codec/ValueDecoderDeriver.scala
+++ b/modules/core/src/main/scala/me/mnedokushev/zio/apache/parquet/core/codec/ValueDecoderDeriver.scala
@@ -223,14 +223,16 @@ object ValueDecoderDeriver {
           value match {
             case GroupValue.RecordValue(values) =>
               Unsafe.unsafe { implicit unsafe =>
-                record.construct(
-                  Chunk
-                    .fromIterable(record.fields.map(f => values(f.name)))
-                    .zip(fields.map(_.unwrap))
-                    .map { case (v, decoder) =>
-                      decoder.decode(v)
-                    }
-                ).flatMap(transform.f) match {
+                record
+                  .construct(
+                    Chunk
+                      .fromIterable(record.fields.map(f => values(f.name)))
+                      .zip(fields.map(_.unwrap))
+                      .map { case (v, decoder) =>
+                        decoder.decode(v)
+                      }
+                  )
+                  .flatMap(transform.f) match {
                   case Right(v)     => v
                   case Left(reason) =>
                     throw DecoderError(s"Couldn't decode $value: $reason")

--- a/modules/core/src/main/scala/me/mnedokushev/zio/apache/parquet/core/codec/ValueDecoderDeriver.scala
+++ b/modules/core/src/main/scala/me/mnedokushev/zio/apache/parquet/core/codec/ValueDecoderDeriver.scala
@@ -230,7 +230,7 @@ object ValueDecoderDeriver {
                     .map { case (v, decoder) =>
                       decoder.decode(v)
                     }
-                ).flatMap(v => transform.f(v)) match {
+                ).flatMap(transform.f) match {
                   case Right(v)     => v
                   case Left(reason) =>
                     throw DecoderError(s"Couldn't decode $value: $reason")

--- a/modules/core/src/main/scala/me/mnedokushev/zio/apache/parquet/core/codec/ValueEncoderDeriver.scala
+++ b/modules/core/src/main/scala/me/mnedokushev/zio/apache/parquet/core/codec/ValueEncoderDeriver.scala
@@ -185,7 +185,7 @@ object ValueEncoderDeriver {
         private def enc[A1](v: A, field: Schema.Field[A, A1], encoder: ValueEncoder[?]) =
           encoder.asInstanceOf[ValueEncoder[A1]].encode(field.get(v))
 
-override def encode(value: B): Value =
+        override def encode(value: B): Value =
           transform.g(value) match {
             case Right(v)     =>
               Value.record(

--- a/modules/core/src/main/scala/me/mnedokushev/zio/apache/parquet/core/codec/ValueEncoderDeriver.scala
+++ b/modules/core/src/main/scala/me/mnedokushev/zio/apache/parquet/core/codec/ValueEncoderDeriver.scala
@@ -180,8 +180,25 @@ object ValueEncoderDeriver {
       transform: Schema.Transform[A, B, ?],
       fields: => Chunk[Deriver.WrappedF[ValueEncoder, ?]],
       summoned: => Option[ValueEncoder[B]]
-    ): ValueEncoder[B] = ???
+    ): ValueEncoder[B] = summoned.getOrElse {
+      new ValueEncoder[B] {
+        private def enc[A1](v: A, field: Schema.Field[A, A1], encoder: ValueEncoder[?]) =
+          encoder.asInstanceOf[ValueEncoder[A1]].encode(field.get(v))
 
+        override def encode(value: B): Value =
+          Value.record(
+            record.fields
+              .zip(fields.map(_.unwrap))
+              .map { case (field, encoder) =>
+                transform.g(value) match {
+                  case Right(v) => field.name -> enc(v, field, encoder)
+                  case Left(_)  => throw EncoderError(s"Failed to encode transformed record for value $value")
+                }
+              }
+              .toMap
+          )
+      }
+    }
   }.cached
 
   val summoned: Deriver[ValueEncoder] = default.autoAcceptSummoned

--- a/modules/core/src/test/scala-2.13+/me/mnedokushev/zio/apache/parquet/core/Fixtures.scala
+++ b/modules/core/src/test/scala-2.13+/me/mnedokushev/zio/apache/parquet/core/Fixtures.scala
@@ -20,6 +20,40 @@ import java.util.{ Currency, UUID }
 
 object Fixtures {
 
+  // unable to generate code for case classes with more than 120 int fields due to following error:
+  // tested with jdk 11.0.23 64bit
+  // Error while emitting me/mnedokushev/zio/apache/parquet/core/codec/SchemaEncoderDeriverSpec$MaxArityRecord$
+  // Method too large: me/mnedokushev/zio/apache/parquet/core/codec/SchemaEncoderDeriverSpec$MaxArityRecord$.derivedSchema0$lzyINIT4$1$$anonfun$364 (Lscala/collection/immutable/ListMap;)Lscala/util/Either;
+  case class Arity23(
+    a: Int,
+    b: Option[String],
+    c: Int,
+    d: Int,
+    e: Int,
+    f: Int,
+    g: Int,
+    h: Int,
+    i: Int,
+    j: Int,
+    k: Int,
+    l: Int,
+    m: Int,
+    n: Int,
+    o: Int,
+    p: Int,
+    q: Int,
+    r: Int,
+    s: Int,
+    t: Int,
+    u: Int,
+    v: Int,
+    w: Int
+  )
+  object Arity23 {
+    implicit lazy val schema: Schema[Arity23] =
+      DeriveSchema.gen[Arity23]
+  }
+
   case class MyRecord(a: String, b: Int, child: MyRecord.Child, enm: MyRecord.Enum, opt: Option[Int])
 
   object MyRecord {

--- a/modules/core/src/test/scala/me/mnedokushev/zio/apache/parquet/core/codec/SchemaEncoderDeriverSpec.scala
+++ b/modules/core/src/test/scala/me/mnedokushev/zio/apache/parquet/core/codec/SchemaEncoderDeriverSpec.scala
@@ -30,15 +30,34 @@ object SchemaEncoderDeriverSpec extends ZIOSpecDefault {
   // Error while emitting me/mnedokushev/zio/apache/parquet/core/codec/SchemaEncoderDeriverSpec$MaxArityRecord$
   // Method too large: me/mnedokushev/zio/apache/parquet/core/codec/SchemaEncoderDeriverSpec$MaxArityRecord$.derivedSchema0$lzyINIT4$1$$anonfun$364 (Lscala/collection/immutable/ListMap;)Lscala/util/Either;
   case class BigRecord(
-    a: Int, b: Option[String], c: Int, d:Int, e:Int, f:Int,
-    g:Int, h:Int, i:Int, j:Int, k:Int, l:Int, m:Int, n:Int,
-    o:Int, p:Int, q:Int, r:Int, s:Int, t:Int, u:Int, v:Int,
-    w:Int
+    a: Int,
+    b: Option[String],
+    c: Int,
+    d: Int,
+    e: Int,
+    f: Int,
+    g: Int,
+    h: Int,
+    i: Int,
+    j: Int,
+    k: Int,
+    l: Int,
+    m: Int,
+    n: Int,
+    o: Int,
+    p: Int,
+    q: Int,
+    r: Int,
+    s: Int,
+    t: Int,
+    u: Int,
+    v: Int,
+    w: Int
   )
   object BigRecord {
     implicit val schema: Schema[BigRecord] = DeriveSchema.gen[BigRecord]
   }
-  
+
   // Helper for being able to extract type parameter A from a given schema in order to cast the type of encoder<
   private def encode[A](encoder: SchemaEncoder[?], schema: Schema[A], name: String, optional: Boolean) =
     encoder.asInstanceOf[SchemaEncoder[A]].encode(schema, name, optional)

--- a/modules/core/src/test/scala/me/mnedokushev/zio/apache/parquet/core/codec/SchemaEncoderDeriverSpec.scala
+++ b/modules/core/src/test/scala/me/mnedokushev/zio/apache/parquet/core/codec/SchemaEncoderDeriverSpec.scala
@@ -7,6 +7,7 @@ import zio.schema._
 import zio.test._
 
 import java.util.UUID
+import me.mnedokushev.zio.apache.parquet.core.Fixtures
 //import scala.annotation.nowarn
 
 object SchemaEncoderDeriverSpec extends ZIOSpecDefault {
@@ -23,39 +24,6 @@ object SchemaEncoderDeriverSpec extends ZIOSpecDefault {
   case class Record(a: Int, b: Option[String])
   object Record {
     implicit val schema: Schema[Record] = DeriveSchema.gen[Record]
-  }
-
-  // unable to generate code for case classes with more than 120 int fields due to following error:
-  // tested with jdk 11.0.23 64bit
-  // Error while emitting me/mnedokushev/zio/apache/parquet/core/codec/SchemaEncoderDeriverSpec$MaxArityRecord$
-  // Method too large: me/mnedokushev/zio/apache/parquet/core/codec/SchemaEncoderDeriverSpec$MaxArityRecord$.derivedSchema0$lzyINIT4$1$$anonfun$364 (Lscala/collection/immutable/ListMap;)Lscala/util/Either;
-  case class BigRecord(
-    a: Int,
-    b: Option[String],
-    c: Int,
-    d: Int,
-    e: Int,
-    f: Int,
-    g: Int,
-    h: Int,
-    i: Int,
-    j: Int,
-    k: Int,
-    l: Int,
-    m: Int,
-    n: Int,
-    o: Int,
-    p: Int,
-    q: Int,
-    r: Int,
-    s: Int,
-    t: Int,
-    u: Int,
-    v: Int,
-    w: Int
-  )
-  object BigRecord {
-    implicit val schema: Schema[BigRecord] = DeriveSchema.gen[BigRecord]
   }
 
   // Helper for being able to extract type parameter A from a given schema in order to cast the type of encoder<
@@ -147,11 +115,11 @@ object SchemaEncoderDeriverSpec extends ZIOSpecDefault {
           tpeRequired == schemaDef.required.named(name)
         )
       },
-      test("arity > 22") {
+      test("record arity > 22") {
         val name        = "arity"
-        val encoder     = Derive.derive[SchemaEncoder, BigRecord](SchemaEncoderDeriver.default)
-        val tpeOptional = encoder.encode(BigRecord.schema, name, optional = true)
-        val tpeRequired = encoder.encode(BigRecord.schema, name, optional = false)
+        val encoder     = Derive.derive[SchemaEncoder, Fixtures.Arity23](SchemaEncoderDeriver.default)
+        val tpeOptional = encoder.encode(Fixtures.Arity23.schema, name, optional = true)
+        val tpeRequired = encoder.encode(Fixtures.Arity23.schema, name, optional = false)
         val schemaDef   = Schemas.record(
           Chunk(
             Schemas.int.required.named("a"),

--- a/modules/core/src/test/scala/me/mnedokushev/zio/apache/parquet/core/codec/SchemaEncoderDeriverSpec.scala
+++ b/modules/core/src/test/scala/me/mnedokushev/zio/apache/parquet/core/codec/SchemaEncoderDeriverSpec.scala
@@ -20,16 +20,58 @@ object SchemaEncoderDeriverSpec extends ZIOSpecDefault {
     implicit val schema: Schema[MyEnum] = DeriveSchema.gen[MyEnum]
   }
 
-  case class Record(
+  case class Record(a: Int, b: Option[String])
+  object Record {
+    implicit val schema: Schema[Record] = DeriveSchema.gen[Record]
+  }
+
+  case class BigRecord(
     a: Int, b: Option[String], c: Int, d:Int, e:Int, f:Int,
     g:Int, h:Int, i:Int, j:Int, k:Int, l:Int, m:Int, n:Int,
     o:Int, p:Int, q:Int, r:Int, s:Int, t:Int, u:Int, v:Int,
     w:Int
   )
-  object Record {
-    implicit val schema: Schema[Record] = DeriveSchema.gen[Record]
+  object BigRecord {
+    implicit val schema: Schema[BigRecord] = DeriveSchema.gen[BigRecord]
   }
 
+  case class MaxArityRecord(
+    f1:Int, f2:Int, f3:Int, f4:Int, f5:Int, f6:Int, f7:Int, f8:Int, f9:Int, f10:Int,
+    f11:Int, f12:Int, f13:Int, f14:Int, f15:Int, f16:Int, f17:Int, f18:Int, f19:Int, f20:Int,
+    f21:Int, f22:Int, f23:Int, f24:Int, f25:Int, f26:Int, f27:Int, f28:Int, f29:Int, f30:Int,
+    f31:Int, f32:Int, f33:Int, f34:Int, f35:Int, f36:Int, f37:Int, f38:Int, f39:Int, f40:Int,
+    f41:Int, f42:Int, f43:Int, f44:Int, f45:Int, f46:Int, f47:Int, f48:Int, f49:Int, f50:Int,
+    f51:Int, f52:Int, f53:Int, f54:Int, f55:Int, f56:Int, f57:Int, f58:Int, f59:Int, f60:Int,
+    f61:Int, f62:Int, f63:Int, f64:Int, f65:Int, f66:Int, f67:Int, f68:Int, f69:Int, f70:Int,
+    f71:Int, f72:Int, f73:Int, f74:Int, f75:Int, f76:Int, f77:Int, f78:Int, f79:Int, f80:Int,
+    f81:Int, f82:Int, f83:Int, f84:Int, f85:Int, f86:Int, f87:Int, f88:Int, f89:Int, f90:Int,
+    f91:Int, f92:Int, f93:Int, f94:Int, f95:Int, f96:Int, f97:Int, f98:Int, f99:Int, f100:Int,
+    f101:Int, f102:Int, f103:Int, f104:Int, f105:Int, f106:Int, f107:Int, f108:Int, f109:Int, f110:Int,
+    f111:Int, f112:Int, f113:Int, f114:Int, f115:Int, f116:Int, f117:Int, f118:Int, f119:Int, f120:Int,
+    f121:Int, f122:Int, f123:Int, f124:Int, f125:Int, f126:Int, f127:Int, f128:Int, f129:Int, f130:Int,
+    f131:Int, f132:Int, f133:Int, f134:Int, f135:Int, f136:Int, f137:Int, f138:Int, f139:Int, f140:Int,
+    f141:Int, f142:Int, f143:Int, f144:Int, f145:Int, f146:Int, f147:Int, f148:Int, f149:Int, f150:Int,
+    f151:Int, f152:Int, f153:Int, f154:Int, f155:Int, f156:Int, f157:Int, f158:Int, f159:Int, f160:Int,
+    f161:Int, f162:Int, f163:Int, f164:Int, f165:Int, f166:Int, f167:Int, f168:Int, f169:Int, f170:Int,
+    f171:Int, f172:Int, f173:Int, f174:Int, f175:Int, f176:Int, f177:Int, f178:Int, f179:Int, f180:Int,
+    f181:Int, f182:Int, f183:Int, f184:Int, f185:Int, f186:Int, f187:Int, f188:Int, f189:Int, f190:Int,
+    f191:Int, f192:Int, f193:Int, f194:Int, f195:Int, f196:Int, f197:Int, f198:Int, f199:Int, f200:Int,
+    f201:Int, f202:Int, f203:Int, f204:Int, f205:Int, f206:Int, f207:Int, f208:Int, f209:Int, f210:Int,
+    f211:Int, f212:Int, f213:Int, f214:Int, f215:Int, f216:Int, f217:Int, f218:Int, f219:Int, f220:Int,
+    f221:Int, f222:Int, f223:Int, f224:Int, f225:Int, f226:Int, f227:Int, f228:Int, f229:Int, f230:Int,
+    f231:Int, f232:Int, f233:Int, f234:Int, f235:Int, f236:Int, f237:Int, f238:Int, f239:Int, f240:Int,
+    f241:Int, f242:Int, f243:Int, f244:Int, f245:Int, f246:Int, f247:Int, f248:Int, f249:Int, f250:Int,
+    f251:Int, f252:Int, f253:Int, f254:Int
+  )
+
+  object MaxArityRecord {
+    // unable to generate code for case classes with more than 120 int fields due to following error:
+    // tested with jdk 11.0.23 64bit
+    // Error while emitting me/mnedokushev/zio/apache/parquet/core/codec/SchemaEncoderDeriverSpec$MaxArityRecord$
+    // Method too large: me/mnedokushev/zio/apache/parquet/core/codec/SchemaEncoderDeriverSpec$MaxArityRecord$.derivedSchema0$lzyINIT4$1$$anonfun$364 (Lscala/collection/immutable/ListMap;)Lscala/util/Either;
+    // implicit val schema: Schema[MaxArityRecord] = DeriveSchema.gen[MaxArityRecord]
+  }
+  
   // Helper for being able to extract type parameter A from a given schema in order to cast the type of encoder<
   private def encode[A](encoder: SchemaEncoder[?], schema: Schema[A], name: String, optional: Boolean) =
     encoder.asInstanceOf[SchemaEncoder[A]].encode(schema, name, optional)
@@ -107,6 +149,23 @@ object SchemaEncoderDeriverSpec extends ZIOSpecDefault {
         val encoder     = Derive.derive[SchemaEncoder, Record](SchemaEncoderDeriver.default)
         val tpeOptional = encoder.encode(Record.schema, name, optional = true)
         val tpeRequired = encoder.encode(Record.schema, name, optional = false)
+        val schemaDef   = Schemas.record(
+          Chunk(
+            Schemas.int.required.named("a"),
+            Schemas.string.optional.named("b")
+          )
+        )
+
+        assertTrue(
+          tpeOptional == schemaDef.optional.named(name),
+          tpeRequired == schemaDef.required.named(name)
+        )
+      },
+      test("arity > 22") {
+        val name        = "arity"
+        val encoder     = Derive.derive[SchemaEncoder, BigRecord](SchemaEncoderDeriver.default)
+        val tpeOptional = encoder.encode(BigRecord.schema, name, optional = true)
+        val tpeRequired = encoder.encode(BigRecord.schema, name, optional = false)
         val schemaDef   = Schemas.record(
           Chunk(
             Schemas.int.required.named("a"),

--- a/modules/core/src/test/scala/me/mnedokushev/zio/apache/parquet/core/codec/SchemaEncoderDeriverSpec.scala
+++ b/modules/core/src/test/scala/me/mnedokushev/zio/apache/parquet/core/codec/SchemaEncoderDeriverSpec.scala
@@ -20,7 +20,12 @@ object SchemaEncoderDeriverSpec extends ZIOSpecDefault {
     implicit val schema: Schema[MyEnum] = DeriveSchema.gen[MyEnum]
   }
 
-  case class Record(a: Int, b: Option[String])
+  case class Record(
+    a: Int, b: Option[String], c: Int, d:Int, e:Int, f:Int,
+    g:Int, h:Int, i:Int, j:Int, k:Int, l:Int, m:Int, n:Int,
+    o:Int, p:Int, q:Int, r:Int, s:Int, t:Int, u:Int, v:Int,
+    w:Int
+  )
   object Record {
     implicit val schema: Schema[Record] = DeriveSchema.gen[Record]
   }
@@ -105,7 +110,28 @@ object SchemaEncoderDeriverSpec extends ZIOSpecDefault {
         val schemaDef   = Schemas.record(
           Chunk(
             Schemas.int.required.named("a"),
-            Schemas.string.optional.named("b")
+            Schemas.string.optional.named("b"),
+            Schemas.int.required.named("c"),
+            Schemas.int.required.named("d"),
+            Schemas.int.required.named("e"),
+            Schemas.int.required.named("f"),
+            Schemas.int.required.named("g"),
+            Schemas.int.required.named("h"),
+            Schemas.int.required.named("i"),
+            Schemas.int.required.named("j"),
+            Schemas.int.required.named("k"),
+            Schemas.int.required.named("l"),
+            Schemas.int.required.named("m"),
+            Schemas.int.required.named("n"),
+            Schemas.int.required.named("o"),
+            Schemas.int.required.named("p"),
+            Schemas.int.required.named("q"),
+            Schemas.int.required.named("r"),
+            Schemas.int.required.named("s"),
+            Schemas.int.required.named("t"),
+            Schemas.int.required.named("u"),
+            Schemas.int.required.named("v"),
+            Schemas.int.required.named("w")
           )
         )
 

--- a/modules/core/src/test/scala/me/mnedokushev/zio/apache/parquet/core/codec/SchemaEncoderDeriverSpec.scala
+++ b/modules/core/src/test/scala/me/mnedokushev/zio/apache/parquet/core/codec/SchemaEncoderDeriverSpec.scala
@@ -25,6 +25,10 @@ object SchemaEncoderDeriverSpec extends ZIOSpecDefault {
     implicit val schema: Schema[Record] = DeriveSchema.gen[Record]
   }
 
+  // unable to generate code for case classes with more than 120 int fields due to following error:
+  // tested with jdk 11.0.23 64bit
+  // Error while emitting me/mnedokushev/zio/apache/parquet/core/codec/SchemaEncoderDeriverSpec$MaxArityRecord$
+  // Method too large: me/mnedokushev/zio/apache/parquet/core/codec/SchemaEncoderDeriverSpec$MaxArityRecord$.derivedSchema0$lzyINIT4$1$$anonfun$364 (Lscala/collection/immutable/ListMap;)Lscala/util/Either;
   case class BigRecord(
     a: Int, b: Option[String], c: Int, d:Int, e:Int, f:Int,
     g:Int, h:Int, i:Int, j:Int, k:Int, l:Int, m:Int, n:Int,
@@ -33,43 +37,6 @@ object SchemaEncoderDeriverSpec extends ZIOSpecDefault {
   )
   object BigRecord {
     implicit val schema: Schema[BigRecord] = DeriveSchema.gen[BigRecord]
-  }
-
-  case class MaxArityRecord(
-    f1:Int, f2:Int, f3:Int, f4:Int, f5:Int, f6:Int, f7:Int, f8:Int, f9:Int, f10:Int,
-    f11:Int, f12:Int, f13:Int, f14:Int, f15:Int, f16:Int, f17:Int, f18:Int, f19:Int, f20:Int,
-    f21:Int, f22:Int, f23:Int, f24:Int, f25:Int, f26:Int, f27:Int, f28:Int, f29:Int, f30:Int,
-    f31:Int, f32:Int, f33:Int, f34:Int, f35:Int, f36:Int, f37:Int, f38:Int, f39:Int, f40:Int,
-    f41:Int, f42:Int, f43:Int, f44:Int, f45:Int, f46:Int, f47:Int, f48:Int, f49:Int, f50:Int,
-    f51:Int, f52:Int, f53:Int, f54:Int, f55:Int, f56:Int, f57:Int, f58:Int, f59:Int, f60:Int,
-    f61:Int, f62:Int, f63:Int, f64:Int, f65:Int, f66:Int, f67:Int, f68:Int, f69:Int, f70:Int,
-    f71:Int, f72:Int, f73:Int, f74:Int, f75:Int, f76:Int, f77:Int, f78:Int, f79:Int, f80:Int,
-    f81:Int, f82:Int, f83:Int, f84:Int, f85:Int, f86:Int, f87:Int, f88:Int, f89:Int, f90:Int,
-    f91:Int, f92:Int, f93:Int, f94:Int, f95:Int, f96:Int, f97:Int, f98:Int, f99:Int, f100:Int,
-    f101:Int, f102:Int, f103:Int, f104:Int, f105:Int, f106:Int, f107:Int, f108:Int, f109:Int, f110:Int,
-    f111:Int, f112:Int, f113:Int, f114:Int, f115:Int, f116:Int, f117:Int, f118:Int, f119:Int, f120:Int,
-    f121:Int, f122:Int, f123:Int, f124:Int, f125:Int, f126:Int, f127:Int, f128:Int, f129:Int, f130:Int,
-    f131:Int, f132:Int, f133:Int, f134:Int, f135:Int, f136:Int, f137:Int, f138:Int, f139:Int, f140:Int,
-    f141:Int, f142:Int, f143:Int, f144:Int, f145:Int, f146:Int, f147:Int, f148:Int, f149:Int, f150:Int,
-    f151:Int, f152:Int, f153:Int, f154:Int, f155:Int, f156:Int, f157:Int, f158:Int, f159:Int, f160:Int,
-    f161:Int, f162:Int, f163:Int, f164:Int, f165:Int, f166:Int, f167:Int, f168:Int, f169:Int, f170:Int,
-    f171:Int, f172:Int, f173:Int, f174:Int, f175:Int, f176:Int, f177:Int, f178:Int, f179:Int, f180:Int,
-    f181:Int, f182:Int, f183:Int, f184:Int, f185:Int, f186:Int, f187:Int, f188:Int, f189:Int, f190:Int,
-    f191:Int, f192:Int, f193:Int, f194:Int, f195:Int, f196:Int, f197:Int, f198:Int, f199:Int, f200:Int,
-    f201:Int, f202:Int, f203:Int, f204:Int, f205:Int, f206:Int, f207:Int, f208:Int, f209:Int, f210:Int,
-    f211:Int, f212:Int, f213:Int, f214:Int, f215:Int, f216:Int, f217:Int, f218:Int, f219:Int, f220:Int,
-    f221:Int, f222:Int, f223:Int, f224:Int, f225:Int, f226:Int, f227:Int, f228:Int, f229:Int, f230:Int,
-    f231:Int, f232:Int, f233:Int, f234:Int, f235:Int, f236:Int, f237:Int, f238:Int, f239:Int, f240:Int,
-    f241:Int, f242:Int, f243:Int, f244:Int, f245:Int, f246:Int, f247:Int, f248:Int, f249:Int, f250:Int,
-    f251:Int, f252:Int, f253:Int, f254:Int
-  )
-
-  object MaxArityRecord {
-    // unable to generate code for case classes with more than 120 int fields due to following error:
-    // tested with jdk 11.0.23 64bit
-    // Error while emitting me/mnedokushev/zio/apache/parquet/core/codec/SchemaEncoderDeriverSpec$MaxArityRecord$
-    // Method too large: me/mnedokushev/zio/apache/parquet/core/codec/SchemaEncoderDeriverSpec$MaxArityRecord$.derivedSchema0$lzyINIT4$1$$anonfun$364 (Lscala/collection/immutable/ListMap;)Lscala/util/Either;
-    // implicit val schema: Schema[MaxArityRecord] = DeriveSchema.gen[MaxArityRecord]
   }
   
   // Helper for being able to extract type parameter A from a given schema in order to cast the type of encoder<

--- a/modules/core/src/test/scala/me/mnedokushev/zio/apache/parquet/core/codec/ValueCodecDeriverSpec.scala
+++ b/modules/core/src/test/scala/me/mnedokushev/zio/apache/parquet/core/codec/ValueCodecDeriverSpec.scala
@@ -43,15 +43,20 @@ object ValueCodecDeriverSpec extends ZIOSpecDefault {
     implicit val schema: Schema[MyEnum] = DeriveSchema.gen[MyEnum]
   }
 
-  case class Record(a: Int, b: Boolean, c: Option[String], d: List[Int], e: Map[String, Int])
+  case class Record(
+    a: Int, b: Boolean, c: Option[String], d: List[Int], e: Map[String, Int],
+    f: Int = 6, g: Int = 7, h: Int = 8, i:Int = 9, j:Int = 10, k:Int = 11,
+    l: Int = 12, m: Int = 13, n: Int = 14, o:Int = 15, p:Int = 16, q:Int = 17,
+    r: Int = 18, s: Int = 19, t: Int = 20, u:Int = 21, v:Int = 22, w:Int = 23
+  )
   object Record {
     implicit val schema: Schema[Record] = DeriveSchema.gen[Record]
   }
 
-  case class SummonedRecord(a: Int, b: Boolean, c: Option[String], d: Option[Int])
-  object SummonedRecord {
-    implicit val schema: Schema[SummonedRecord] = DeriveSchema.gen[SummonedRecord]
-  }
+//  case class SummonedRecord(a: Int, b: Boolean, c: Option[String], d: Option[Int])
+//  object SummonedRecord {
+//    implicit val schema: Schema[SummonedRecord] = DeriveSchema.gen[SummonedRecord]
+//  }
 
   override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("ValueCodecDeriverSpec")(

--- a/modules/core/src/test/scala/me/mnedokushev/zio/apache/parquet/core/codec/ValueCodecDeriverSpec.scala
+++ b/modules/core/src/test/scala/me/mnedokushev/zio/apache/parquet/core/codec/ValueCodecDeriverSpec.scala
@@ -44,20 +44,39 @@ object ValueCodecDeriverSpec extends ZIOSpecDefault {
   }
 
   case class Record(a: Int, b: Boolean, c: Option[String], d: List[Int], e: Map[String, Int])
-  object Record {
+  object Record    {
     implicit val schema: Schema[Record] = DeriveSchema.gen[Record]
   }
 
   case class BigRecord(
-    a: Int, b: Boolean, c: Option[String], d: List[Int], e: Map[String, Int],
-    f: Int = 6, g: Int = 7, h: Int = 8, i:Int = 9, j:Int = 10, k:Int = 11,
-    l: Int = 12, m: Int = 13, n: Int = 14, o:Int = 15, p:Int = 16, q:Int = 17,
-    r: Int = 18, s: Int = 19, t: Int = 20, u:Int = 21, v:Int = 22, w:Int = 23
+    a: Int,
+    b: Boolean,
+    c: Option[String],
+    d: List[Int],
+    e: Map[String, Int],
+    f: Int = 6,
+    g: Int = 7,
+    h: Int = 8,
+    i: Int = 9,
+    j: Int = 10,
+    k: Int = 11,
+    l: Int = 12,
+    m: Int = 13,
+    n: Int = 14,
+    o: Int = 15,
+    p: Int = 16,
+    q: Int = 17,
+    r: Int = 18,
+    s: Int = 19,
+    t: Int = 20,
+    u: Int = 21,
+    v: Int = 22,
+    w: Int = 23
   )
   object BigRecord {
     implicit val schema: Schema[BigRecord] = DeriveSchema.gen[BigRecord]
   }
-  
+
   case class SummonedRecord(a: Int, b: Boolean, c: Option[String], d: Option[Int])
   object SummonedRecord {
     implicit val schema: Schema[SummonedRecord] = DeriveSchema.gen[SummonedRecord]

--- a/modules/core/src/test/scala/me/mnedokushev/zio/apache/parquet/core/codec/ValueCodecDeriverSpec.scala
+++ b/modules/core/src/test/scala/me/mnedokushev/zio/apache/parquet/core/codec/ValueCodecDeriverSpec.scala
@@ -27,6 +27,7 @@ import java.time.{
   ZonedDateTime
 }
 import java.util.{ Currency, UUID }
+import me.mnedokushev.zio.apache.parquet.core.Fixtures
 
 //import java.nio.ByteBuffer
 //import java.util.UUID
@@ -44,37 +45,8 @@ object ValueCodecDeriverSpec extends ZIOSpecDefault {
   }
 
   case class Record(a: Int, b: Boolean, c: Option[String], d: List[Int], e: Map[String, Int])
-  object Record    {
+  object Record {
     implicit val schema: Schema[Record] = DeriveSchema.gen[Record]
-  }
-
-  case class BigRecord(
-    a: Int,
-    b: Boolean,
-    c: Option[String],
-    d: List[Int],
-    e: Map[String, Int],
-    f: Int = 6,
-    g: Int = 7,
-    h: Int = 8,
-    i: Int = 9,
-    j: Int = 10,
-    k: Int = 11,
-    l: Int = 12,
-    m: Int = 13,
-    n: Int = 14,
-    o: Int = 15,
-    p: Int = 16,
-    q: Int = 17,
-    r: Int = 18,
-    s: Int = 19,
-    t: Int = 20,
-    u: Int = 21,
-    v: Int = 22,
-    w: Int = 23
-  )
-  object BigRecord {
-    implicit val schema: Schema[BigRecord] = DeriveSchema.gen[BigRecord]
   }
 
   case class SummonedRecord(a: Int, b: Boolean, c: Option[String], d: Option[Int])
@@ -356,10 +328,34 @@ object ValueCodecDeriverSpec extends ZIOSpecDefault {
           result <- decoder.decodeZIO(value)
         } yield assertTrue(result == payload)
       },
-      test("arity > 22") {
-        val encoder = Derive.derive[ValueEncoder, BigRecord](ValueEncoderDeriver.default)
-        val decoder = Derive.derive[ValueDecoder, BigRecord](ValueDecoderDeriver.default)
-        val payload = BigRecord(2, false, Some("data"), List(1), Map("zio" -> 1))
+      test("record arity > 22") {
+        val encoder = Derive.derive[ValueEncoder, Fixtures.Arity23](ValueEncoderDeriver.default)
+        val decoder = Derive.derive[ValueDecoder, Fixtures.Arity23](ValueDecoderDeriver.default)
+        val payload = Fixtures.Arity23(
+          a = 1,
+          b = None,
+          c = 3,
+          d = 4,
+          e = 5,
+          f = 6,
+          g = 7,
+          h = 8,
+          i = 9,
+          j = 10,
+          k = 11,
+          l = 12,
+          m = 13,
+          n = 14,
+          o = 15,
+          p = 16,
+          q = 17,
+          r = 18,
+          s = 19,
+          t = 20,
+          u = 21,
+          v = 22,
+          w = 23
+        )
 
         for {
           value  <- encoder.encodeZIO(payload)

--- a/modules/core/src/test/scala/me/mnedokushev/zio/apache/parquet/core/codec/ValueCodecDeriverSpec.scala
+++ b/modules/core/src/test/scala/me/mnedokushev/zio/apache/parquet/core/codec/ValueCodecDeriverSpec.scala
@@ -43,20 +43,25 @@ object ValueCodecDeriverSpec extends ZIOSpecDefault {
     implicit val schema: Schema[MyEnum] = DeriveSchema.gen[MyEnum]
   }
 
-  case class Record(
+  case class Record(a: Int, b: Boolean, c: Option[String], d: List[Int], e: Map[String, Int])
+  object Record {
+    implicit val schema: Schema[Record] = DeriveSchema.gen[Record]
+  }
+
+  case class BigRecord(
     a: Int, b: Boolean, c: Option[String], d: List[Int], e: Map[String, Int],
     f: Int = 6, g: Int = 7, h: Int = 8, i:Int = 9, j:Int = 10, k:Int = 11,
     l: Int = 12, m: Int = 13, n: Int = 14, o:Int = 15, p:Int = 16, q:Int = 17,
     r: Int = 18, s: Int = 19, t: Int = 20, u:Int = 21, v:Int = 22, w:Int = 23
   )
-  object Record {
-    implicit val schema: Schema[Record] = DeriveSchema.gen[Record]
+  object BigRecord {
+    implicit val schema: Schema[BigRecord] = DeriveSchema.gen[BigRecord]
   }
-
-//  case class SummonedRecord(a: Int, b: Boolean, c: Option[String], d: Option[Int])
-//  object SummonedRecord {
-//    implicit val schema: Schema[SummonedRecord] = DeriveSchema.gen[SummonedRecord]
-//  }
+  
+  case class SummonedRecord(a: Int, b: Boolean, c: Option[String], d: Option[Int])
+  object SummonedRecord {
+    implicit val schema: Schema[SummonedRecord] = DeriveSchema.gen[SummonedRecord]
+  }
 
   override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("ValueCodecDeriverSpec")(
@@ -326,6 +331,16 @@ object ValueCodecDeriverSpec extends ZIOSpecDefault {
         val encoder = Derive.derive[ValueEncoder, Record](ValueEncoderDeriver.default)
         val decoder = Derive.derive[ValueDecoder, Record](ValueDecoderDeriver.default)
         val payload = Record(2, false, Some("data"), List(1), Map("zio" -> 1))
+
+        for {
+          value  <- encoder.encodeZIO(payload)
+          result <- decoder.decodeZIO(value)
+        } yield assertTrue(result == payload)
+      },
+      test("arity > 22") {
+        val encoder = Derive.derive[ValueEncoder, BigRecord](ValueEncoderDeriver.default)
+        val decoder = Derive.derive[ValueDecoder, BigRecord](ValueDecoderDeriver.default)
+        val payload = BigRecord(2, false, Some("data"), List(1), Map("zio" -> 1))
 
         for {
           value  <- encoder.encodeZIO(payload)

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -5,12 +5,13 @@ import scalafix.sbt.ScalafixPlugin.autoImport.scalafixSemanticdb
 object BuildHelper {
 
   def stdSettings(projectName: String): Seq[Def.Setting[_]] = Seq(
-    name              := s"zio-apache-parquet-$projectName",
-    organization      := "me.mnedokushev",
+    name                          := s"zio-apache-parquet-$projectName",
+    organization                  := "me.mnedokushev",
     libraryDependencies ++= betterMonadicFor(scalaVersion.value),
-    semanticdbEnabled := true,
-    semanticdbVersion := scalafixSemanticdb.revision,
-    Test / fork       := true,
+    ThisBuild / semanticdbEnabled := scalaVersion.value != Scala3,
+    ThisBuild / semanticdbOptions += "-P:semanticdb:synthetics:on",
+    ThisBuild / semanticdbVersion := scalafixSemanticdb.revision,
+    Test / fork                   := true,
     Test / unmanagedSourceDirectories ++= crossVersionSources(scalaVersion.value, "test", baseDirectory.value),
     Test / unmanagedSourceDirectories ++= crossVersionSources(scalaVersion.value, "main", baseDirectory.value),
     libraryDependencies ++= {
@@ -25,7 +26,7 @@ object BuildHelper {
 
   val Scala212 = "2.12.20"
   val Scala213 = "2.13.16"
-  val Scala3   = "3.6.4"
+  val Scala3   = "3.3.5"
 
   private def betterMonadicFor(scalaVersion: String) =
     CrossVersion.partialVersion(scalaVersion) match {

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -5,13 +5,12 @@ import scalafix.sbt.ScalafixPlugin.autoImport.scalafixSemanticdb
 object BuildHelper {
 
   def stdSettings(projectName: String): Seq[Def.Setting[_]] = Seq(
-    name                          := s"zio-apache-parquet-$projectName",
-    organization                  := "me.mnedokushev",
+    name              := s"zio-apache-parquet-$projectName",
+    organization      := "me.mnedokushev",
     libraryDependencies ++= betterMonadicFor(scalaVersion.value),
-    ThisBuild / semanticdbEnabled := scalaVersion.value != Scala3,
-    ThisBuild / semanticdbOptions += "-P:semanticdb:synthetics:on",
-    ThisBuild / semanticdbVersion := scalafixSemanticdb.revision,
-    Test / fork                   := true,
+    semanticdbEnabled := true,
+    semanticdbVersion := scalafixSemanticdb.revision,
+    Test / fork       := true,
     Test / unmanagedSourceDirectories ++= crossVersionSources(scalaVersion.value, "test", baseDirectory.value),
     Test / unmanagedSourceDirectories ++= crossVersionSources(scalaVersion.value, "main", baseDirectory.value),
     libraryDependencies ++= {

--- a/project/Dep.scala
+++ b/project/Dep.scala
@@ -5,7 +5,7 @@ object Dep {
 
   object V {
     val zio                   = "2.1.17"
-    val zioSchema             = "1.6.6"
+    val zioSchema             = "1.7.0"
     val scalaCollectionCompat = "2.13.0"
     val apacheParquet         = "1.15.0"
     val apacheHadoop          = "3.4.1"
@@ -33,7 +33,7 @@ object Dep {
 
   lazy val scalaCollectionCompat = O.scalaLangModules %% "scala-collection-compat" % V.scalaCollectionCompat
 
-  lazy val scalaReflect = Def.setting("org.scala-lang" % "scala-reflect" % scalaVersion.value)
+  lazy val scalaReflect = Def.setting("org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided")
 
   lazy val core = Seq(
     zio,


### PR DESCRIPTION
TODO: determine where transform param should be used in SchemaEncoderDeriver.deriveTransformedRecord

Ziverge zio-schema derivation reference: https://www.ziverge.com/post/type-class-derivation-with-zio-schema